### PR TITLE
Add DockerHub Deploy Action

### DIFF
--- a/.github/workflows/docker-deploy.yaml
+++ b/.github/workflows/docker-deploy.yaml
@@ -1,0 +1,49 @@
+name: docker-deploy
+
+on:
+  push:
+    branches: main
+
+jobs:
+  images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cuda:
+          - "11.0"
+          - "10.2"
+        img_type:
+          - runtime
+        os:
+          - ubuntu18.04
+        python:
+          - "3.8"
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: gpucibot
+          password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          pull: true
+          file: ./common/docker/Dockerfile.training.unified
+          tags: rapidsai/could-ml:cuda${{ matrix.cuda }}-${{ matrix.img_type }}-${{ matrix.os }}-py${{ matrix.python }}
+          build-args: |
+            rapids_cuda_version=${{ matrix.cuda }}
+  # description:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Update repo description
+  #       uses: peter-evans/dockerhub-description@v2
+  #       with:
+  #         username: gpucibot
+  #         password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
+  #         repository: rapidsai/could-ml
+  #         readme-filepath: common/docker/DockerHubREADME.md

--- a/.github/workflows/docker-deploy.yaml
+++ b/.github/workflows/docker-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
           - "11.0"
           - "10.2"
         img_type:
-          - runtime
+          - base
         os:
           - ubuntu18.04
         python:

--- a/common/docker/Dockerfile.training.unified
+++ b/common/docker/Dockerfile.training.unified
@@ -1,5 +1,5 @@
 ARG rapids_cuda_version="10.1"
-ARG rapids_release_type="runtime"
+ARG rapids_release_type="base"
 ARG rapids_os="ubuntu18.04"
 ARG rapids_python="py3.8"
 FROM rapidsai/rapidsai:cuda${rapids_cuda_version}-${rapids_release_type}-${rapids_os}-${rapids_python}

--- a/common/docker/Dockerfile.training.unified
+++ b/common/docker/Dockerfile.training.unified
@@ -10,7 +10,8 @@ ENV PYTHONUNBUFFERED=True
 RUN apt update -y \
     && apt install -y --no-install-recommends build-essential \
     && apt autoremove -y \
-    && apt clean -y
+    && apt clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # AWS Requirements
 ARG aws_dataset_directory="1_year"
@@ -41,7 +42,7 @@ ENV RAPIDS_GCP_INSTALL_PATH=${gcp_install_path}
 
 # AWS Install
 RUN mkdir -p ${RAPIDS_AWS_INSTALL_PATH}
-ADD aws/code/entrypoint.sh \
+COPY aws/code/entrypoint.sh \
     aws/code/HPOConfig.py \
     aws/code/HPODatasets.py \
     aws/code/MLWorkflow.py \
@@ -58,7 +59,7 @@ RUN . /opt/conda/etc/profile.d/conda.sh \
 
 # Azure Install
 RUN mkdir -p ${RAPIDS_AZURE_INSTALL_PATH}
-ADD azure/* \
+COPY azure/* \
     /opt/rapids/azure/
 
 RUN . /opt/conda/etc/profile.d/conda.sh \
@@ -72,7 +73,7 @@ RUN . /opt/conda/etc/profile.d/conda.sh \
 
 # GCP Install
 RUN mkdir -p ${RAPIDS_GCP_INSTALL_PATH}
-ADD gcp/docker/infrastructure/* \
+COPY gcp/docker/infrastructure/* \
     /opt/rapids/gcp/
 
 RUN . /opt/conda/etc/profile.d/conda.sh \
@@ -85,7 +86,7 @@ RUN . /opt/conda/etc/profile.d/conda.sh \
         'ray[tune]'
 
 RUN mkdir -p /opt/rapids_cloudml
-ADD common/docker/infrastructure/* \
+COPY common/docker/infrastructure/* \
      /opt/rapids_cloudml/
 
 ## Unified entrypoint


### PR DESCRIPTION
This PR adds a GitHub Action for building and deploying the cloud-ml image to DockerHub. It uses Docker's [build-push-action](https://github.com/docker/build-push-action). The DockerHub repo's description can also be automatically updated by un-commenting the lines at the bottom of `.github/workflows/docker-deploy.yaml` and providing the correct `readme-filepath`.

Additionally, I've made a few tweaks to the Dockerfile as @zronaghi requested. Namely, the following changes were made:

- Added `&& rm -rf /var/lib/apt/lists/*` after the `apt` operations to remove extraneous files and help reduce image size
- Switched all `ADD` commands to `COPY` commands based on Docker's article about Dockerfile best practices ([src](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy))