### PR TITLE
Remove Docker build from GitHub Action

### DIFF
--- a/.github/workflows/docker-deploy.yaml
+++ b/.github/workflows/docker-deploy.yaml
@@ -1,49 +1,19 @@
-name: docker-deploy
+name: dockerhub-description
 
 on:
   push:
     branches: main
+    paths:
+      - README.md
 
 jobs:
-  images:
+  deploy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cuda:
-          - "11.0"
-          - "10.2"
-        img_type:
-          - base
-        os:
-          - ubuntu18.04
-        python:
-          - "3.8"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v2
         with:
           username: gpucibot
           password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          pull: true
-          file: ./common/docker/Dockerfile.training.unified
-          tags: rapidsai/could-ml:cuda${{ matrix.cuda }}-${{ matrix.img_type }}-${{ matrix.os }}-py${{ matrix.python }}
-          build-args: |
-            rapids_cuda_version=${{ matrix.cuda }}
-  # description:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Update repo description
-  #       uses: peter-evans/dockerhub-description@v2
-  #       with:
-  #         username: gpucibot
-  #         password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
-  #         repository: rapidsai/could-ml
-  #         readme-filepath: common/docker/DockerHubREADME.md
+          repository: rapidsai/cloud-ml
+          readme-filepath: README.md

--- a/common/docker/Dockerfile.training.unified
+++ b/common/docker/Dockerfile.training.unified
@@ -1,8 +1,9 @@
+ARG rapids_version="0.17"
 ARG rapids_cuda_version="10.1"
 ARG rapids_release_type="base"
 ARG rapids_os="ubuntu18.04"
 ARG rapids_python="py3.8"
-FROM rapidsai/rapidsai:cuda${rapids_cuda_version}-${rapids_release_type}-${rapids_os}-${rapids_python}
+FROM rapidsai/rapidsai:${rapids_version}-cuda${rapids_cuda_version}-${rapids_release_type}-${rapids_os}-${rapids_python}
 
 # ensure printed output/log-messages retain correct order
 ENV PYTHONUNBUFFERED=True


### PR DESCRIPTION
Since the GitHub Action nodes do not have the storage capacity to build the `cloud-ml` images, this PR removes the build/deploy step from the GitHub Action. The DockerHub description update section of the GitHub Action has been uncommented and temporarily configured to use the repo's `README.md` file for the DockerHub description.

Finally, the Dockerfile has been updated to use a new build-argument, `rapids_version` that will be used as part of the image build/tagging process.