### PR TITLE
Add `latest` tag & Fix GitHub Action

### DIFF
--- a/.github/workflows/docker-description.yaml
+++ b/.github/workflows/docker-description.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: main
     paths:
-      - README.md
+      - common/docker/DockerHubREADME.md
       - .github/workflows/docker-description.yaml
 
 jobs:

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -53,7 +53,7 @@ GPUCI_RETRY_MAX=5
 GPUCI_RETRY_SLEEP=120
 gpuci_retry docker push ${DOCKER_IMG}:${DOCKER_TAG}
 
-if [ "$TAG" = "0.18-cuda11.0-base-ubuntu18.04-py3.8" ]; then
+if [ "$TAG" = "${RAPIDS_VER}-cuda11.0-base-ubuntu18.04-py3.8" ]; then
   docker tag ${DOCKER_IMG}:${DOCKER_TAG} ${DOCKER_IMG}:latest
   gpuci_retry docker push ${DOCKER_IMG}:latest
 fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -52,3 +52,8 @@ gpuci_logger "Starting upload..."
 GPUCI_RETRY_MAX=5
 GPUCI_RETRY_SLEEP=120
 gpuci_retry docker push ${DOCKER_IMG}:${DOCKER_TAG}
+
+if [ "$TAG" = "0.18-cuda11.0-base-ubuntu18.04-py3.8" ]; then
+  docker tag ${DOCKER_IMG}:${DOCKER_TAG} ${DOCKER_IMG}:latest
+  gpuci_retry docker push ${DOCKER_IMG}:latest
+fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -53,7 +53,7 @@ GPUCI_RETRY_MAX=5
 GPUCI_RETRY_SLEEP=120
 gpuci_retry docker push ${DOCKER_IMG}:${DOCKER_TAG}
 
-if [ "$TAG" = "${RAPIDS_VER}-cuda11.0-base-ubuntu18.04-py3.8" ]; then
+if [ "$DOCKER_TAG" = "${RAPIDS_VER}-cuda11.0-base-ubuntu18.04-py3.8" ]; then
   docker tag ${DOCKER_IMG}:${DOCKER_TAG} ${DOCKER_IMG}:latest
   gpuci_retry docker push ${DOCKER_IMG}:latest
 fi


### PR DESCRIPTION
This PR includes the following changes:

- Updates the CI scripts to also upload the `0.18-cuda11.0-base-ubuntu18.04-py3.8` image as the `latest` tag (per request from @zronaghi)
- Fixes the GitHub Action for the DockerHub README to ensure that it runs whenever `common/docker/DockerHubREADME.md` is changed. I accidentally overlooked this change in #67.