### PR TITLE
Add Ubuntu20.04 & CentOS7

### DIFF
--- a/ci/axis.yaml
+++ b/ci/axis.yaml
@@ -8,6 +8,8 @@ IMG_TYPE:
 
 LINUX_VER:
   - ubuntu18.04
+  - ubuntu20.04
+  - centos7
 
 PYTHON_VER:
   - "3.8"


### PR DESCRIPTION
This PR adds `ubuntu20.04` and `centos7` to the axis file for CI. This will ensure that cloud-ml images are built for those OSes.