### PR TITLE
Remove centos7 & add `exclude` key

### DIFF
--- a/ci/axis.yaml
+++ b/ci/axis.yaml
@@ -9,10 +9,13 @@ IMG_TYPE:
 LINUX_VER:
   - ubuntu18.04
   - ubuntu20.04
-  - centos7
 
 PYTHON_VER:
   - "3.8"
 
 RAPIDS_VER:
   - "0.19"
+
+exclude:
+  - LINUX_VER: ubuntu20.04
+    CUDA_VER: "10.2"


### PR DESCRIPTION
Currently the `cloud-ml` images do not support `CentOS` since their Dockerfiles use the `apt` command indiscriminately. This PR removes it from the axis file.

Additionally, this PR adds an `exclude` list to exclude certain combinations from being built. `ubuntu20.04` does not have a `10.2` image, so that combination was added to the `exclude` list.