### PR TITLE
Fixed the problem of old version of dask-ml getting installed when building cloudml Docker image

### DIFF
--- a/common/docker/Dockerfile.training.unified
+++ b/common/docker/Dockerfile.training.unified
@@ -59,7 +59,7 @@ COPY aws/code/workflows/MLWorkflowMultiCPU.py \
 
 RUN . /opt/conda/etc/profile.d/conda.sh \
     && conda activate rapids \
-    && conda install -c anaconda -c conda-forge \
+    && conda install -c conda-forge \
         flask \
         dask-ml \
     && conda clean --all \


### PR DESCRIPTION
This PR:

- Removes the channel `anaconda` when installing `dask-ml` and `flask` in the cloudml docker image so that the latest version of the two libraries can be installed from the channel `conda-forge` 