### PR TITLE
[REVIEW] Update Azure notebooks to 21.10

### DIFF
--- a/azure/kubernetes/Detailed_setup_guide.md
+++ b/azure/kubernetes/Detailed_setup_guide.md
@@ -202,8 +202,8 @@ We need to authenticate AKS to pull the images from ACR. For this purpose we wil
 Now we build and push the pod images to ACR. We have a `Dockerfile` in the current directory. From the current directory do the following:
 
 ```bash
-docker build -t $ACR_NAME.azurecr.io/aks-mnmg/dask-unified:21.06 .
-docker push $ACR_NAME.azurecr.io/aks-mnmg/dask-unified:21.06
+docker build -t $ACR_NAME.azurecr.io/aks-mnmg/dask-unified:latest .
+docker push $ACR_NAME.azurecr.io/aks-mnmg/dask-unified:latest
 ```
 
 

--- a/azure/kubernetes/Dockerfile
+++ b/azure/kubernetes/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rapidsai/rapidsai-core:21.06-cuda11.2-runtime-ubuntu18.04-py3.8
+FROM docker.io/rapidsai/rapidsai-core:21.10-cuda11.2-runtime-ubuntu18.04-py3.8
 
 RUN source activate rapids \
     && pip install xgboost \

--- a/azure/kubernetes/podspecs/azure/cpu-worker-specs.yml
+++ b/azure/kubernetes/podspecs/azure/cpu-worker-specs.yml
@@ -10,7 +10,7 @@ spec:
       value: "worker"
       effect: "NoSchedule"
   containers:
-    - image: <username>.azurecr.io/aks-mnmg/dask-unified:21.06
+    - image: acrnanthini.azurecr.io/aks-mnmg/dask-unified:latest
       imagePullPolicy: IfNotPresent
       args: [ dask-worker, $(DASK_SCHEDULER_ADDRESS) ]
       name: dask-worker

--- a/azure/kubernetes/podspecs/azure/cuda-worker-specs.yml
+++ b/azure/kubernetes/podspecs/azure/cuda-worker-specs.yml
@@ -10,7 +10,7 @@ spec:
       value: "worker"
       effect: "NoSchedule"
   containers:
-    - image: <username>.azurecr.io/aks-mnmg/dask-unified:21.06
+    - image: acrnanthini.azurecr.io/aks-mnmg/dask-unified:latest
       imagePullPolicy: IfNotPresent
       args: [ dask-cuda-worker, $(DASK_SCHEDULER_ADDRESS), --rmm-managed-memory ]
       name: dask-cuda-worker

--- a/azure/kubernetes/podspecs/azure/scheduler-specs.yml
+++ b/azure/kubernetes/podspecs/azure/scheduler-specs.yml
@@ -10,7 +10,7 @@ spec:
       value: "scheduler"
       effect: "NoSchedule"
   containers:
-    - image: <username>.azurecr.io/aks-mnmg/dask-unified:21.06
+    - image: acrnanthini.azurecr.io/aks-mnmg/dask-unified:latest
       imagePullPolicy: IfNotPresent
       args: [ dask-scheduler ]
       name: dask-scheduler

--- a/azure/notebooks/Dockerfile
+++ b/azure/notebooks/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapidsai/rapidsai-core:21.06-cuda11.0-base-ubuntu18.04-py3.8
+FROM rapidsai/rapidsai-core:21.10-cuda11.0-base-ubuntu18.04-py3.8
 RUN apt-get update && \
 apt-get install -y fuse && \
 source activate rapids && \

--- a/azure/notebooks/HPO-RAPIDS.ipynb
+++ b/azure/notebooks/HPO-RAPIDS.ipynb
@@ -294,8 +294,8 @@
     "# enable docker\n",
     "docker_config = DockerConfiguration(use_docker=True)\n",
     "\n",
-    "# rapids-cloud-ml image is available in Docker Hub\n",
-    "env.docker.base_image = 'rapidsai/rapidsai-cloud-ml:latest'\n",
+    "env.docker.base_image = None\n",
+    "env.docker.base_dockerfile = \"./Dockerfile\"\n",
     "\n",
     "# use rapids environment in the container, don't build a new conda environment\n",
     "env.python.user_managed_dependencies = True"
@@ -541,7 +541,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/azure/notebooks/remote-explanation/azure-gpu-shap.ipynb
+++ b/azure/notebooks/remote-explanation/azure-gpu-shap.ipynb
@@ -24,7 +24,7 @@
     "# apt-get install -y python3-dev && \\\n",
     "# pip install azureml-core && \\\n",
     "# pip install azureml-interpret && \\\n",
-    "# pip install -e git+https://github.com/interpretml/interpret-community.git#egg=interpret_community\\&subdirectory=python && \\\n",
+    "# pip install interpret-community\n",
     "# pip install raiwidgets"
    ]
   },
@@ -216,25 +216,28 @@
    "outputs": [],
    "source": [
     "from azureml.core import Environment\n",
+    "from azureml.core.runconfig import DockerConfiguration\n",
     "\n",
     "environment_name = \"rapids\"\n",
     "\n",
     "env = Environment(environment_name)\n",
-    "env.docker.enabled = True\n",
+    "\n",
+    "docker_config = DockerConfiguration(use_docker=True)\n",
+    "\n",
     "env.docker.base_image = None\n",
-    "#Installing interpret-community from source for now, will update later\n",
     "env.docker.base_dockerfile = \"\"\"\n",
-    "FROM rapidsai/rapidsai:21.06-cuda11.0-runtime-ubuntu18.04-py3.8\n",
+    "FROM rapidsai/rapidsai:21.10-cuda11.2-runtime-ubuntu18.04-py3.8\n",
     "RUN apt-get update && \\\n",
     "apt-get install -y fuse && \\\n",
     "apt-get install -y build-essential && \\\n",
     "apt-get install -y python3-dev && \\\n",
     "source activate rapids && \\\n",
-    "pip install azureml-defaults && \\\n",
+    "pip install azureml-core && \\\n",
     "pip install azureml-interpret && \\\n",
-    "pip install -e git+https://github.com/interpretml/interpret-community.git#egg=interpret_community\\&subdirectory=python && \\\n",
-    "pip install azureml-telemetry\n",
+    "pip install interpret-community\n",
     "\"\"\"\n",
+    "\n",
+    "# use rapids environment in the container, don't build a new conda environment\n",
     "env.python.user_managed_dependencies = True"
    ]
   },
@@ -275,7 +278,8 @@
     "src = ScriptRunConfig(source_directory=project_folder, \n",
     "                      script='train_explain.py',\n",
     "                      compute_target=gpu_cluster,\n",
-    "                      environment=env) \n",
+    "                      environment=env,\n",
+    "                      docker_runtime_config=docker_config) \n",
     "run = experiment.submit(config=src)\n",
     "run"
    ]
@@ -464,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updating references to 21.10 in Azure examples.

The dask-clouprovider notebook cannot be updated at the moment due to issues while installing azureml-opendatasets. 