### PR TITLE
Various improvements to EC2 MNMG example

### DIFF
--- a/aws/rapids_ec2_mnmg.ipynb
+++ b/aws/rapids_ec2_mnmg.ipynb
@@ -122,7 +122,7 @@
    "source": [
     "cluster = EC2Cluster(env_vars=get_aws_credentials(),\n",
     "                     instance_type=\"g4dn.12xlarge\",  # 4 T4 GPUs\n",
-    "                     docker_image=\"rapidsai/rapidsai-nightly:22.08-cuda11.5-runtime-ubuntu20.04-py3.9\",\n",
+    "                     docker_image=\"rapidsai/rapidsai:21.06-cuda11.0-runtime-ubuntu18.04-py3.8\",\n",
     "                     worker_class=\"dask_cuda.CUDAWorker\",\n",
     "                     worker_options = {'rmm-managed-memory':True},\n",
     "                     security_groups=[security_group],\n",

--- a/aws/rapids_ec2_mnmg.ipynb
+++ b/aws/rapids_ec2_mnmg.ipynb
@@ -239,8 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi_df = dask_cudf.read_csv(\"s3://nyc-tlc/trip data/yellow_tripdata_2016-02.csv\",\n",
-    "                             storage_options={\"anon\": True},\n",
+    "taxi_df = dask_cudf.read_csv(\"https://storage.googleapis.com/anaconda-public-data/nyc-taxi/csv/2016/yellow_tripdata_2016-02.csv\",\n",
     "                             dtype=col_dtype)"
    ]
   },

--- a/aws/rapids_ec2_mnmg.ipynb
+++ b/aws/rapids_ec2_mnmg.ipynb
@@ -107,7 +107,8 @@
    "source": [
     "n_workers = 2\n",
     "n_gpus_per_worker = 4\n",
-    "security_group = \"sg-dask\""
+    "security_group = \"sg-dask\"\n",
+    "region_name = \"us-east-1\""
    ]
   },
   {
@@ -120,15 +121,16 @@
    "outputs": [],
    "source": [
     "cluster = EC2Cluster(env_vars=get_aws_credentials(),\n",
-    "                     instance_type=\"p3.8xlarge\", # 4 V100 GPUs\n",
-    "                     docker_image=\"rapidsai/rapidsai:21.06-cuda11.0-runtime-ubuntu18.04-py3.8\",\n",
+    "                     instance_type=\"g4dn.12xlarge\",  # 4 T4 GPUs\n",
+    "                     docker_image=\"rapidsai/rapidsai-core-nightly:22.08-cuda11.5-runtime-ubuntu20.04-py3.9\",\n",
     "                     worker_class=\"dask_cuda.CUDAWorker\",\n",
     "                     worker_options = {'rmm-managed-memory':True},\n",
     "                     security_groups=[security_group],\n",
     "                     docker_args = '--shm-size=256m',\n",
     "                     n_workers=n_workers,\n",
     "                     security=False,\n",
-    "                     availability_zone=\"\")"
+    "                     availability_zone=\"\",\n",
+    "                     region=region_name)"
    ]
   },
   {

--- a/aws/rapids_ec2_mnmg.ipynb
+++ b/aws/rapids_ec2_mnmg.ipynb
@@ -122,7 +122,7 @@
    "source": [
     "cluster = EC2Cluster(env_vars=get_aws_credentials(),\n",
     "                     instance_type=\"g4dn.12xlarge\",  # 4 T4 GPUs\n",
-    "                     docker_image=\"rapidsai/rapidsai-core-nightly:22.08-cuda11.5-runtime-ubuntu20.04-py3.9\",\n",
+    "                     docker_image=\"rapidsai/rapidsai-nightly:22.08-cuda11.5-runtime-ubuntu20.04-py3.9\",\n",
     "                     worker_class=\"dask_cuda.CUDAWorker\",\n",
     "                     worker_options = {'rmm-managed-memory':True},\n",
     "                     security_groups=[security_group],\n",


### PR DESCRIPTION
* Specify the AWS region name
* Use g4dn.12xlarge instance type instead of p3.8xlarge, because p3.8xlarge may be hard to come by (due to global capacity constraints)
* Use a new link for the NYC Taxi data, since it's not available on S3 any more.