### PR TITLE
Indicate the space needed in SageMaker notebook

### DIFF
--- a/aws/rapids_intro.ipynb
+++ b/aws/rapids_intro.ipynb
@@ -21,6 +21,7 @@
     "1. During SageMaker Notebook Instance Startup\n",
     "    - Select a RAPIDS compatible GPU (NVIDIA Pascal or greater with compute capability 6.0+) as the SageMaker Notebook instance type (e.g., ml.p3.2xlarge)\n",
     "    - Attach the lifecycle configuration (via the 'Additional Options' dropdown) provided in this directory (link to directory also in the Appendix of this notebook)\n",
+    "    - Set the volume size to at least 15 GB, to accommodate the Conda tarball.",
     "2. Launch the instance\n",
     "3. Once Jupyter is accessible select the 'rapids-XX' kernel when working with a new notebook.\n",
     "\n",


### PR DESCRIPTION
The default size of 5 GB is not sufficient to hold the Rapids conda package.