### PR TITLE
Remove deprecated normalize option

### DIFF
--- a/aws/rapids_intro.ipynb
+++ b/aws/rapids_intro.ipynb
@@ -88,8 +88,12 @@
    "source": [
     "from cuml import make_regression, train_test_split\n",
     "from cuml.linear_model import LinearRegression as cuLinearRegression\n",
+    "from cuml.pipeline import Pipeline as cuPipeline\n",
+    "from cuml.preprocessing import StandardScaler as cuStandardScaler\n",
     "from cuml.metrics.regression import r2_score\n",
     "from sklearn.linear_model import LinearRegression as skLinearRegression\n",
+    "from sklearn.pipeline import Pipeline as skPipeline\n",
+    "from sklearn.preprocessing import StandardScaler as skStandardScaler\n",
     "\n",
     "# Define parameters\n",
     "n_samples = 2**19 #If you are running on a GPU with less than 16GB RAM, please change to 2**19 or you could run out of memory\n",
@@ -146,11 +150,10 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "ols_sk = skLinearRegression(fit_intercept=True,\n",
-    "                            normalize=True,\n",
-    "                            n_jobs=-1)\n",
-    "\n",
-    "ols_sk.fit(X_train, y_train)"
+    "ols_sk = skLinearRegression(fit_intercept=True, n_jobs=-1)\n",
+    "pipe_sk = skPipeline(steps=[('scaler', skStandardScaler()),\n",
+    "                            ('linear', ols_sk)])\n",
+    "pipe_sk.fit(X_train, y_train)"
    ]
   },
   {
@@ -161,7 +164,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "predict_sk = ols_sk.predict(X_test)"
+    "predict_sk = pipe_sk.predict(X_test)"
    ]
   },
   {
@@ -191,11 +194,11 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "ols_cuml = cuLinearRegression(fit_intercept=True,\n",
-    "                              normalize=True,\n",
-    "                              algorithm='eig')\n",
+    "ols_cuml = cuLinearRegression(fit_intercept=True, algorithm='eig')\n",
+    "pipe_cuml = cuPipeline(steps=[('scaler', cuStandardScaler()),\n",
+    "                              ('linear', ols_cuml)])\n",
     "\n",
-    "ols_cuml.fit(X_cudf, y_cudf)"
+    "pipe_cuml.fit(X_cudf, y_cudf)"
    ]
   },
   {
@@ -206,7 +209,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "predict_cuml = ols_cuml.predict(X_cudf_test)"
+    "predict_cuml = pipe_cuml.predict(X_cudf_test)"
    ]
   },
   {
@@ -235,8 +238,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"R^2 score (SKL):  %s\" % r2_score_sk)\n",
-    "print(\"R^2 score (cuML): %s\" % r2_score_cuml)"
+    "print(f\"R^2 score (SKL):  {r2_score_sk}\")\n",
+    "print(f\"R^2 score (cuML): {r2_score_cuml}\")"
    ]
   },
   {


### PR DESCRIPTION
The `normalize=True` option has been [marked as deprecated](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html) in the latest scikit-learn. Use pipelines instead.