### PR TITLE
Add unmaintained note to READMEs for GCP AI Platform examples

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -1,3 +1,6 @@
+# **This guide is deprecated an no longer maintained.**
+
+
 ## Quick start guide
 Here we will go over some common tasks, related to utilizing RAPIDS on the GCP AI Platform. Note that strings containing '[YOUR_XXX]' indicate items that you will need to supply, based on your specific resource names and environment.
 

--- a/gcp/notebook_setup/README.md
+++ b/gcp/notebook_setup/README.md
@@ -1,3 +1,5 @@
+# **This guide is deprecated an no longer maintained.**
+
 ## **Pack and Deploy Conda Environments for RAPIDS on Google Cloud Platform (GCP)**
 This section describes the process required to:
 1. Package and deploy a RAPIDS conda environment via helper script


### PR DESCRIPTION
These examples are for GCP's AI Platform which are no longer developed compared to Vertex AI, and as discussed in the examples tracker, noting in the READMEs that these examples are no longer maintained.

xref https://github.com/rapidsai/deployment/issues/11