### PR TITLE
Use G4 instances to avoid capacity issue

### DIFF
--- a/aws/rapids_studio_hpo.ipynb
+++ b/aws/rapids_studio_hpo.ipynb
@@ -196,7 +196,7 @@
    "metadata": {},
    "source": [
     "Depending on the workflow you have chosen, your instance should reflect the specifications needed. For example, for the singleGPU workflow, you should choose an instance with a GPU, such as the p3.2xlarge instance. You can [read about Amazon EC2 Instance Types here](https://aws.amazon.com/ec2/instance-types/). \n",
-    "> e.g., For the 10_year dataset option, we suggest ml.p3.8xlarge instances (4 GPUs) and ml.m5.24xlarge CPU instances ( we will need upwards of 200GB CPU RAM during model training)."
+    "> e.g., For the 10_year dataset option, we suggest ml.g4dn.12xlarge instances (4 GPUs) and ml.m5.24xlarge CPU instances ( we will need upwards of 200GB CPU RAM during model training)."
    ]
   },
   {
@@ -208,7 +208,7 @@
    "outputs": [],
    "source": [
     "# we will recommend a compute instance type, feel free to modify \n",
-    "instance_type = 'ml.p3.2xlarge'  # recommend_instance_type(ml_workflow_choice, dataset_directory)"
+    "instance_type = 'ml.g4dn.2xlarge'  # recommend_instance_type(ml_workflow_choice, dataset_directory)"
    ]
   },
   {


### PR DESCRIPTION
AWS often fails to provision P3 instances in EC2 due to global capacity shortage. So for now the HPO Studio notebook should use the G4 instance type.