### PR TITLE
Point to deployment doc from GKE Dask HPO example

### DIFF
--- a/gke-dask/notebooks/xgboost-gpu-hpo-job-parallel-k8s.ipynb
+++ b/gke-dask/notebooks/xgboost-gpu-hpo-job-parallel-k8s.ipynb
@@ -10,7 +10,7 @@
     "Choosing an optimal set of hyperparameters is a daunting task, especially for algorithms like XGBoost that have many hyperparameters to tune. In this notebook, we will show how to speed up hyperparameter optimization by running multiple training jobs in parallel on a Kubernetes cluster.\n",
     "\n",
     "# Prerequisites\n",
-    "Please follow instructions in [Accelerating ETL on KubeFlow with RAPIDS](https://developer.nvidia.com/blog/accelerating-etl-on-kubeflow-with-rapids/) to set up a GPU-enabled Kubernetes cluster and Kubeflow."
+    "Please follow instructions in [Dask Operator: Installation](https://docs.rapids.ai/deployment/stable/tools/kubernetes/dask-operator.html#installation) to install the Dask operator on top of a GPU-enabled Kubernetes cluster. (For the purpose of this example, you may ignore other sections of the linked document.) Then install Kubeflow by following instructions in [Installing Kubeflow](https://www.kubeflow.org/docs/started/installing-kubeflow/). You may choose any method; we tested this example after installing Kubeflow from manifests."
    ]
   },
   {


### PR DESCRIPTION
Blog posts tend to be outdated over time. It's better to point the deployment doc instead, since it will be updated and maintained.