### PR TITLE
add higgs HPO notebook to cloud-ml-examples repo

### DIFF
--- a/aws/rapids_sagemaker_higgs/README.md
+++ b/aws/rapids_sagemaker_higgs/README.md
@@ -1,0 +1,3 @@
+This repository contains code and config files supporting the following blog post:
+
+https://medium.com/@shashankprasanna/running-rapids-experiments-at-scale-using-amazon-sagemaker-d516420f165b

--- a/aws/rapids_sagemaker_higgs/docker/Dockerfile
+++ b/aws/rapids_sagemaker_higgs/docker/Dockerfile
@@ -1,0 +1,12 @@
+# FROM rapidsai/rapidsai-cloud-ml:latest
+FROM rapidsai/rapidsai-nightly:22.12-cuda11.5-runtime-ubuntu18.04-py3.9
+
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential 
+
+RUN source activate rapids && pip install sagemaker-training 
+
+# Copies the training code inside the container
+COPY rapids-higgs.py /opt/ml/code/rapids-higgs.py
+
+# Defines rapids-higgs.py as script entry point
+ENV SAGEMAKER_PROGRAM rapids-higgs.py

--- a/aws/rapids_sagemaker_higgs/docker/rapids-higgs.py
+++ b/aws/rapids_sagemaker_higgs/docker/rapids-higgs.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from cuml import RandomForestClassifier as cuRF
+from cuml.preprocessing.model_selection import train_test_split
+import cudf
+import numpy as np
+import pandas as pd
+from sklearn.metrics import accuracy_score
+import os
+from urllib.request import urlretrieve
+import gzip
+import argparse
+
+
+def main(args):
+    
+    # SageMaker options
+    model_dir       = args.model_dir
+    data_dir        = args.data_dir
+        
+    col_names = ['label'] + ["col-{}".format(i) for i in range(2, 30)] # Assign column names
+    dtypes_ls = ['int32'] + ['float32' for _ in range(2, 30)] # Assign dtypes to each column
+    
+    data = cudf.read_csv(data_dir+'HIGGS.csv', names=col_names, dtype=dtypes_ls)
+    X_train, X_test, y_train, y_test = train_test_split(data, 'label', train_size=0.70)
+
+    # Hyper-parameters
+    hyperparams={
+    'n_estimators'       : args.n_estimators,
+    'max_depth'          : args.max_depth,
+    'n_bins'             : args.n_bins,
+    'split_criterion'    : args.split_criterion,
+    'bootstrap'          : args.bootstrap,
+    'max_leaves'         : args.max_leaves,
+    'max_features'       : args.max_features
+    }
+
+    cu_rf = cuRF(**hyperparams)
+    cu_rf.fit(X_train, y_train)
+
+    print("test_acc:", accuracy_score(cu_rf.predict(X_test), y_test)
+
+    
+if __name__ == "__main__":
+    
+    parser = argparse.ArgumentParser()
+    
+    # Hyper-parameters
+    parser.add_argument('--n_estimators',        type=int,   default=20)
+    parser.add_argument('--max_depth',           type=int,   default=16)
+    parser.add_argument('--n_bins',              type=int,   default=8)
+    parser.add_argument('--split_criterion',     type=int,   default=0)
+    parser.add_argument('--bootstrap',           type=bool,  default=True)
+    parser.add_argument('--max_leaves',          type=int,   default=-1)
+    parser.add_argument('--max_features',        type=float, default=0.2)
+    
+    # SageMaker parameters
+    parser.add_argument('--model_dir',        type=str)
+    parser.add_argument('--model_output_dir', type=str,   default='/opt/ml/output/')
+    parser.add_argument('--data_dir',         type=str,   default='/opt/ml/input/data/dataset/')
+    
+    args = parser.parse_args()
+    main(args)
+
+

--- a/aws/rapids_sagemaker_higgs/sagemaker_rapids_higgs.ipynb
+++ b/aws/rapids_sagemaker_higgs/sagemaker_rapids_higgs.ipynb
@@ -1,0 +1,418 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Running RAPIDS hyperparameter experiments at scale on Amazon SageMaker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import packages and create Amazon SageMaker and Boto3 sessions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "import time\n",
+    "import boto3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "execution_role = sagemaker.get_execution_role()\n",
+    "session = sagemaker.Session()\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "account = boto3.client('sts').get_caller_identity().get('Account')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "account, region"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upload the higgs-boson dataset to s3 bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir dataset\n",
+    "!wget -P dataset https://archive.ics.uci.edu/ml/machine-learning-databases/00280/HIGGS.csv.gz\n",
+    "!gunzip dataset/HIGGS.csv.gz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_data_dir = session.upload_data(path='dataset', key_prefix='dataset/higgs-dataset')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_data_dir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Download latest RAPIDS container with cloud-ml examples\n",
+    "\n",
+    "Extend the container by copying the training script and installing [SageMaker Training toolkit](https://github.com/aws/sagemaker-training-toolkit) to makes RAPIDS compatible with SageMaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# estimator_info = {\n",
+    "#     'rapids_container': 'rapidsai/rapidsai-cloud-ml:latest',\n",
+    "#     'ecr_image': 'sagemaker-rapids-cloud-ml:latest',\n",
+    "#     'ecr_repository': 'sagemaker-rapids-cloud-ml'\n",
+    "# }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator_info = {\n",
+    "    'rapids_container':'rapidsai/rapidsai-nightly:22.12-cuda11.5-runtime-ubuntu18.04-py3.9',\n",
+    "    'ecr_image':'sagemaker-rapids-nightly',\n",
+    "    'ecr_repository':'sagemaker-rapids-nightly'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "!docker pull {estimator_info['rapids_container']}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat docker/Dockerfile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#FROM rapidsai/rapidsai-cloud-ml:latest\n",
+    "#!docker build -t sagemaker-rapids:latest docker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker build -t sagemaker-rapids-nightly docker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Publish to Elastic Container Registry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: SageMaker does not support using training images from private docker registry (ie. DockerHub), so we need to push\n",
+    "the SageMaker-compatible \\\n",
+    "RAPIDS container to the Amazon Elastic Container Registry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ECR_container_fullname = f\"{account}.dkr.ecr.{region}.amazonaws.com/{estimator_info['ecr_image']}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ECR_container_fullname "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker tag {estimator_info['rapids_container']} {ECR_container_fullname}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print( f\"source      : {estimator_info['rapids_container']}\\n\"\n",
+    "       f\"destination : {ECR_container_fullname}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!aws ecr create-repository --repository-name {estimator_info['ecr_repository']}\n",
+    "!$(aws ecr get-login --no-include-email --region {region})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker push {ECR_container_fullname}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Define hyperparameters: start with best guess values\n",
+    "Find the full list of Random Forest hyperparameters here in the RAPIDS doc page:\n",
+    "<br>\n",
+    "https://docs.rapids.ai/api/cuml/stable/api.html#random-forest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hyperparams={ \n",
+    "    'n_estimators'       : 15,\n",
+    "    'max_depth'          : 5,\n",
+    "    'n_bins'             : 8,\n",
+    "    'split_criterion'    : 0,      # GINI:0, ENTROPY:1\n",
+    "    'bootstrap'          : 0,      # true: sample with replacement, false: sample without replacement\n",
+    "    'max_leaves'         : -1,     # unlimited leaves\n",
+    "    'max_features'       : 0.2, \n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.estimator import Estimator\n",
+    "\n",
+    "rapids_estimator = Estimator(image_uri=ECR_container_fullname,\n",
+    "                          role=execution_role,\n",
+    "                          instance_count=1,\n",
+    "                          instance_type='ml.g4dn.4xlarge',\n",
+    "                          hyperparameters=hyperparams,\n",
+    "                          metric_definitions=[{'Name': 'test_acc', 'Regex': 'test_acc: ([0-9\\\\.]+)'}])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "rapids_estimator.fit(inputs = s3_data_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.tuner import IntegerParameter, CategoricalParameter, ContinuousParameter, HyperparameterTuner\n",
+    "\n",
+    "hyperparameter_ranges = {\n",
+    "    'n_estimators'        : IntegerParameter(10, 200), \n",
+    "    'max_depth'           : IntegerParameter(1, 22),\n",
+    "    'n_bins'              : IntegerParameter(5, 24),\n",
+    "    'split_criterion'     : CategoricalParameter([0, 1]),\n",
+    "    'bootstrap'           : CategoricalParameter([True, False]),\n",
+    "    'max_features'        : ContinuousParameter(0.01, 0.5),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.estimator import Estimator\n",
+    "\n",
+    "rapids_estimator = Estimator(image_uri=image,\n",
+    "                          role=execution_role,\n",
+    "                          instance_count=1,\n",
+    "                          instance_type='ml.p3.2xlarge',\n",
+    "                          hyperparameters=hyperparams,\n",
+    "                          metric_definitions=[{'Name': 'test_acc', 'Regex': 'test_acc: ([0-9\\\\.]+)'}])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tuner = HyperparameterTuner(rapids_estimator,\n",
+    "                            objective_metric_name='test_acc',\n",
+    "                            hyperparameter_ranges=hyperparameter_ranges,\n",
+    "                            strategy='Bayesian',\n",
+    "                            max_jobs=1,\n",
+    "                            max_parallel_jobs=1,\n",
+    "                            objective_type='Maximize',\n",
+    "                            metric_definitions=[{'Name': 'test_acc', 'Regex': 'test_acc: ([0-9\\\\.]+)'}])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_name = 'rapidsHPO' + time.strftime('%Y-%m-%d-%H-%M-%S-%j', time.gmtime())\n",
+    "tuner.fit({'dataset': s3_data_dir}, job_name=job_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clean up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Delete S3 buckets and files you don't need\n",
+    "- Kill training jobs that you don't want running\n",
+    "- Delete container images and the repository you just created"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aws ecr delete-repository --force --repository-name"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
In testing issue https://github.com/rapidsai/deployment/issues/13, this PR adds the [notebook example](https://github.com/shashankprasanna/sagemaker-rapids) referenced in this [blog](https://medium.com/rapids-ai/running-rapids-experiments-at-scale-using-amazon-sagemaker-d516420f165b) to `cloud-ml-examples` for visibility.